### PR TITLE
Remove print

### DIFF
--- a/amplitude/__init__.py
+++ b/amplitude/__init__.py
@@ -58,8 +58,6 @@ class AmplitudeLogger:
             ('event', json.dumps([event])),
             ]
 
-        print(event_package)
-
         # ++ many other properties
         # details: https://amplitude.zendesk.com/hc/en-us/articles/204771828-HTTP-API
         return event_package


### PR DESCRIPTION
Remove unneeded print statement. Annoying when running tests etc and lots of text prints out.